### PR TITLE
Update the POM and enable the enforcer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+dist: xenial
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>28.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -31,8 +31,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tag/clearvolume</archive>
 		</mailingList>
 	</mailingLists>
 
@@ -97,22 +97,34 @@
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Max Planck Institute of Molecular
 Cell Biology and Genetics.</license.copyrightOwners>
+
+		<!-- NB: Disable strict javadoc syntax checking. -->
+		<doclint>none</doclint>
+
+		<!--
+		NB: javacl is an unshaded-uberjar, which clashes with bridj,
+		opencl4java and javacl-core. It even depends on the latter!
+		For now, let's ignore this issue, since it may not be safe
+		to exclude javacl as a whole...
+		-->
+		<allowedDuplicateClasses>com.nativelibs4java.opencl.*,com.nativelibs4java.util.*,com.ochafik.util.string.StringUtils,org.bridj.*</allowedDuplicateClasses>
+
+		<!-- NB: Deploy releases to the SciJava Maven repository. -->
+		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
 		<clearcl.version>0.5.2</clearcl.version>
-		<cleargl.version>2.2.6</cleargl.version>
 		<clearvolume.version>1.4.2</clearvolume.version>
 		<coremem.version>0.4.6</coremem.version>
-		<enforcer.skip>true</enforcer.skip>
-		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
-		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
-		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		<miglayout-swing.version>5.2</miglayout-swing.version>
+		<orange-extensions.version>1.3.0</orange-extensions.version>
 	</properties>
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<name>ImageJ</name>
-			<url>https://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<name>SciJava</name>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 
@@ -160,6 +172,10 @@ Cell Biology and Genetics.</license.copyrightOwners>
 			<version>${clearvolume.version}</version>
 			<exclusions>
 				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>com.apple</groupId>
 					<artifactId>AppleJavaExtensions</artifactId>
 				</exclusion>
@@ -174,8 +190,8 @@ Cell Biology and Genetics.</license.copyrightOwners>
 		<!-- Other dependencies -->
 		<dependency>
 			<groupId>com.miglayout</groupId>
-			<artifactId>miglayout</artifactId>
-			<version>${miglayout.version}</version>
+			<artifactId>miglayout-swing</artifactId>
+			<version>${miglayout-swing.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jogamp.jogl</groupId>
@@ -189,11 +205,20 @@ Cell Biology and Genetics.</license.copyrightOwners>
 			<artifactId>clearcl</artifactId>
 			<version>${clearcl.version}</version>
 			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>net.coremem</groupId>
+					<artifactId>coremem</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ome</groupId>
+					<artifactId>bio-formats-tools</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>net.clearvolume</groupId>
 			<artifactId>cleargl</artifactId>
-			<version>${cleargl.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 
@@ -201,7 +226,7 @@ Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>com.yuvimasory</groupId>
 			<artifactId>orange-extensions</artifactId>
-			<version>1.3.0</version>
+			<version>${orange-extensions.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -210,6 +235,12 @@ Cell Biology and Genetics.</license.copyrightOwners>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 
@@ -224,16 +255,14 @@ Cell Biology and Genetics.</license.copyrightOwners>
 	</profiles>
 	
 	<build>
-        <plugins>
+		<plugins>
 			<plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-dependency-plugin</artifactId>
-			    <configuration>
-			        <outputDirectory>
-			            ${project.build.directory}
-			        </outputDirectory>
-			    </configuration>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}</outputDirectory>
+				</configuration>
 			</plugin>
-        </plugins>
-    </build>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
This updates imglib2-clearvolume to be compatible with the impending Fiji update. It also finally sets everything up for the maven-enforcer-plugin to run properly and catch various issues in future.

CC @fjug